### PR TITLE
Allow browsing to uma0: device for game loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,6 +694,7 @@ target_link_libraries(${SHORT_NAME}
   SceIofilemgr_stub
   ScePower_stub 
   ScePgf_stub
+  SceAppMgr_stub
   freetype 
   png
   z
@@ -707,14 +708,14 @@ vita_create_self(${PROJECT_NAME}.self ${PROJECT_NAME} ${UNSAFE_FLAG})
 # default build target so that it will be run every time.
 add_custom_target(${PROJECT_NAME}.vpk ALL
   COMMAND ${VITASDK}/bin/vita-mksfoex -s TITLE_ID=${VITA_TITLEID} ${VITA_APP_NAME} ${PROJECT_NAME}.vpk_param.sfo
-  COMMAND ${VITASDK}/bin/vita-pack-vpk.exe -s ${PROJECT_NAME}.vpk_param.sfo -b ${PROJECT_NAME}.self
-  -a sce_sys/icon0.png=sce_sys/icon0.png
-  -a sce_sys/livearea/contents/bg.png=sce_sys/livearea/contents/bg.png
-  -a sce_sys/livearea/contents/startup.png=sce_sys/livearea/contents/startup.png
-  -a sce_sys/livearea/contents/template.xml=sce_sys/livearea/contents/template.xml
-  -a resources/C64=resources/C64
-  -a resources/DRIVES=resources/DRIVES
-  -a resources/PRINTER=resources/PRINTER ${SHORT_NAME}.vpk
+  COMMAND ${VITASDK}/bin/vita-pack-vpk -s ${PROJECT_NAME}.vpk_param.sfo -b ${PROJECT_NAME}.self
+  -a ${CMAKE_SOURCE_DIR}/sce_sys/icon0.png=sce_sys/icon0.png
+  -a ${CMAKE_SOURCE_DIR}/sce_sys/livearea/contents/bg.png=sce_sys/livearea/contents/bg.png
+  -a ${CMAKE_SOURCE_DIR}/sce_sys/livearea/contents/startup.png=sce_sys/livearea/contents/startup.png
+  -a ${CMAKE_SOURCE_DIR}/sce_sys/livearea/contents/template.xml=sce_sys/livearea/contents/template.xml
+  -a ${CMAKE_SOURCE_DIR}/resources/C64=resources/C64
+  -a ${CMAKE_SOURCE_DIR}/resources/DRIVES=resources/DRIVES
+  -a ${CMAKE_SOURCE_DIR}/resources/PRINTER=resources/PRINTER ${SHORT_NAME}.vpk
   DEPENDS ${PROJECT_NAME}.self
 )
 

--- a/src/arch/psvita/view/file_explorer.cpp
+++ b/src/arch/psvita/view/file_explorer.cpp
@@ -295,6 +295,25 @@ int FileExplorer::readDirContent(const char* path)
 
 	int fd;
 
+	std::string tmp = path;
+	if (tmp == "") {
+		DirEntry entry;
+		m_path = path;
+		m_list.clear();
+
+		entry.name = "ux0:";
+		entry.path = "ux0:";
+		entry.isFile = false;
+		m_list.push_back(entry);
+
+		entry.name = "uma0:";
+		entry.path = "uma0:";
+		entry.isFile = false;
+		m_list.push_back(entry);
+
+		return RET_OK;
+	}
+
 	if ((fd = sceIoDopen(path)) < 0) {
 		//PSV_DEBUG("sceIoDopen error: 0x%08X\n, path = %s", fd, path);
 	    return RET_DIR_OPEN_ERROR;
@@ -306,7 +325,7 @@ int FileExplorer::readDirContent(const char* path)
 	bool entries_left = true;
 
 	// add slash if needed
-	if (m_path[m_path.size()-1] != '/') 
+	if (m_path[m_path.size()-1] != '/' && m_path[m_path.size()-1] != ':')
 		m_path.append("/");
 
 	while (entries_left)
@@ -354,6 +373,13 @@ void FileExplorer::addParentDirectory()
 		entry.path = tmp;
 		entry.isFile = false;
 		m_list.push_back(entry);
+	}else{
+		if (m_path != ""){
+			entry.name = "..";
+			entry.path = "";
+			entry.isFile = false;
+			m_list.push_back(entry);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1 

I also had to make some small changes to CMAKELISTS to compile with latest VitaSDK.

Please take a look what you think. You can now go to parent to see a kind of virtual "root" that shows ux0: and uma0: for SD2Vita owners who store their game collections on uma0: 